### PR TITLE
fix compile error

### DIFF
--- a/libgo/ctx_win_fiber/context.h
+++ b/libgo/ctx_win_fiber/context.h
@@ -7,11 +7,11 @@ namespace co
     
     struct ContextScopedGuard
     {
-        ContextScopedGuard::ContextScopedGuard()
+        ContextScopedGuard()
         {
             GetTlsContext() = ConvertThreadToFiber(nullptr);
         }
-        ContextScopedGuard::~ContextScopedGuard()
+        ~ContextScopedGuard()
         {
             ConvertFiberToThread();
             GetTlsContext() = nullptr;


### PR DESCRIPTION
修复vs2019编译失败问题：结构体内部定义函数不需要再加结构体名